### PR TITLE
Install Android SDK in CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Android CI
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: AMGQuizApp-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,21 +7,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Extract project
+        run: unzip -q AMGQuizApp.zip
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
-      - name: Gradle cache
+      - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: "8.7"
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
         with:
           api-level: 34
           build-tools: 34.0.0
       - name: Build Debug APK
-        run: ./gradlew assembleDebug
+        run: gradle assembleDebug
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: AMGQuizApp-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
+


### PR DESCRIPTION
## Summary
- ensure GitHub Actions installs Android SDK before running Gradle

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f66cc0a7883268d09c89526f34dd2