### PR TITLE
Move Android CI workflow to repository root

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: AMGQuizApp.zip_unzipped
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -13,10 +16,12 @@ jobs:
           java-version: 17
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
+        with:
+          build-root-directory: AMGQuizApp.zip_unzipped
       - name: Build Debug APK
         run: ./gradlew assembleDebug
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: AMGQuizApp-debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: AMGQuizApp.zip_unzipped/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
- Move Android CI workflow to repository root
- Configure workflow to run Gradle tasks from AMGQuizApp.zip_unzipped

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f69ded4a4832691bd9b09fbe18649